### PR TITLE
fix: need signing region for custom s3 endpoint

### DIFF
--- a/cmd/talos-backup/service/service.go
+++ b/cmd/talos-backup/service/service.go
@@ -40,7 +40,7 @@ func BackupEncryptedSnapshot(ctx context.Context, serviceConfig *config.ServiceC
 
 	defer util.CleanupFile(encryptedFileName)
 
-	client, err := s3.CreateClientWithCustomEndpoint(ctx, serviceConfig.CustomS3Endpoint)
+	client, err := s3.CreateClientWithCustomEndpoint(ctx, serviceConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create S3 client: %w", err)
 	}

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -13,6 +13,7 @@ import (
 type ServiceConfig struct {
 	CustomS3Endpoint   string `yaml:"customS3Endpoint"`
 	Bucket             string `yaml:"bucket"`
+	Region             string `yaml:"region"`
 	S3Prefix           string `yaml:"s3Prefix"`
 	ClusterName        string `yaml:"clusterName"`
 	AgeX25519PublicKey string `yaml:"ageX25519PublicKey"`
@@ -21,6 +22,7 @@ type ServiceConfig struct {
 const (
 	customS3EndpointEnvVar   = "CUSTOM_S3_ENDPOINT"
 	bucketEnvVar             = "BUCKET"
+	regionEnvVar             = "AWS_REGION"
 	s3PrefixEnvVar           = "S3_PREFIX"
 	clusterNameEnvVar        = "CLUSTER_NAME"
 	ageX25519PublicKeyEnvVar = "AGE_X25519_PUBLIC_KEY"
@@ -31,6 +33,7 @@ func GetServiceConfig() *ServiceConfig {
 	return &ServiceConfig{
 		CustomS3Endpoint:   os.Getenv(customS3EndpointEnvVar),
 		Bucket:             os.Getenv(bucketEnvVar),
+		Region:             os.Getenv(regionEnvVar),
 		S3Prefix:           os.Getenv(s3PrefixEnvVar),
 		ClusterName:        os.Getenv(clusterNameEnvVar),
 		AgeX25519PublicKey: os.Getenv(ageX25519PublicKeyEnvVar),

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -33,18 +33,19 @@ func CreateClient(ctx context.Context, conf buconfig.S3Info) (*s3.Client, error)
 
 // CreateClientWithCustomEndpoint returns an S3 client that loads the default AWS configuration.
 // You may optionally specify `customS3Endpoint` for a custom S3 API endpoint.
-func CreateClientWithCustomEndpoint(ctx context.Context, customS3Endpoint string) (*s3.Client, error) {
-	cfg, err := config.LoadDefaultConfig(ctx)
+func CreateClientWithCustomEndpoint(ctx context.Context, svcConf *buconfig.ServiceConfig) (*s3.Client, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(svcConf.Region))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load AWS configuration: %w", err)
 	}
 
-	if customS3Endpoint != "" {
+	if svcConf.CustomS3Endpoint != "" {
 		cfg.EndpointResolverWithOptions = aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
 			if true {
 				return aws.Endpoint{
-					URL:               customS3Endpoint,
+					URL:               svcConf.CustomS3Endpoint,
 					HostnameImmutable: true,
+					SigningRegion:     svcConf.Region,
 				}, nil
 			}
 


### PR DESCRIPTION
Need `SigningRegion` when using custom s3 endpoint (like minio), AWS_REGION env var is not enough. 
otherwise you get errors from the go SDK like: 
```
authorization header is malformed; the region is wrong; expecting 'my-minio-region'
```

fixes #8 

