### PR TITLE
chore(ci): create multiplatform (amd&arm) image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-07-03T12:32:21Z by kres 2c4ff8a.
+# Generated on 2024-07-03T13:01:47Z by kres 2c4ff8a.
 
 name: default
 concurrency:
@@ -95,12 +95,14 @@ jobs:
       - name: push-talos-backup
         if: github.event_name != 'pull_request'
         env:
+          PLATFORM: linux/amd64,linux/arm64
           PUSH: "true"
         run: |
           make image-talos-backup
       - name: push-talos-backup-latest
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         env:
+          PLATFORM: linux/amd64,linux/arm64
           PUSH: "true"
         run: |
           make image-talos-backup IMAGE_TAG=latest

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -9,6 +9,12 @@ spec:
       GOOS: linux
       GOARCH: arm64
 ---
+kind: common.Image
+name: image-talos-backup
+spec:
+  extraEnvironment:
+    PLATFORM: linux/amd64,linux/arm64
+---
 kind: auto.CustomSteps
 spec:
   steps:


### PR DESCRIPTION
Currently talos-backup doesn't support ARM64 nodes and only runs on AMD64 nodes. This enables using talos-backup on arm64 nodes.

The image builds on my machine, but I'm confused by the additional kres changes. I just added the `common.Image` step with the `PLATFORM` var specified and executed the latest kres.