### PR TITLE
feat: add support for UsePathStyle in ServiceConfig

### DIFF
--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ServiceConfig holds configuration values for the etcd snapshot service.
-// The parameters CustomS3Endpoint, s3Prefix and clusterName are optional.
+// The parameters CustomS3Endpoint, s3Prefix, clusterName and usePathStyle are optional.
 type ServiceConfig struct {
 	CustomS3Endpoint   string `yaml:"customS3Endpoint"`
 	Bucket             string `yaml:"bucket"`
@@ -17,6 +17,7 @@ type ServiceConfig struct {
 	S3Prefix           string `yaml:"s3Prefix"`
 	ClusterName        string `yaml:"clusterName"`
 	AgeX25519PublicKey string `yaml:"ageX25519PublicKey"`
+	UsePathStyle       bool   `yaml:"usePathStyle"`
 }
 
 const (
@@ -25,6 +26,7 @@ const (
 	regionEnvVar             = "AWS_REGION"
 	s3PrefixEnvVar           = "S3_PREFIX"
 	clusterNameEnvVar        = "CLUSTER_NAME"
+	usePathStyleEnvVar       = "USE_PATH_STYLE"
 	ageX25519PublicKeyEnvVar = "AGE_X25519_PUBLIC_KEY"
 )
 
@@ -36,6 +38,7 @@ func GetServiceConfig() *ServiceConfig {
 		Region:             os.Getenv(regionEnvVar),
 		S3Prefix:           os.Getenv(s3PrefixEnvVar),
 		ClusterName:        os.Getenv(clusterNameEnvVar),
+		UsePathStyle:       os.Getenv(usePathStyleEnvVar) == "false",
 		AgeX25519PublicKey: os.Getenv(ageX25519PublicKeyEnvVar),
 	}
 }

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -32,6 +32,8 @@ func CreateClientWithCustomEndpoint(ctx context.Context, svcConf *buconfig.Servi
 		if svcConf.CustomS3Endpoint != "" {
 			// Ref: https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/endpoints/
 			o.BaseEndpoint = aws.String(svcConf.CustomS3Endpoint)
+			// Ref: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#Options.UsePathStyle
+			o.UsePathStyle = *aws.Bool(svcConf.UsePathStyle)
 		}
 	})
 


### PR DESCRIPTION
This commit adds the `UsePathStyle` field to the `ServiceConfig` struct in `pkg/config/service.go`. The `UsePathStyle` parameter is optional and allows users to specify whether to use path-style URLs for S3 requests. The value of `UsePathStyle` is read from the `USE_PATH_STYLE` environment variable and defaults to `false`.

Refactor the `CreateClientWithCustomEndpoint` function in `pkg/s3/s3.go` to set the `UsePathStyle` option based on the value of `svcConf.UsePathStyle`. This ensures that the S3 client uses path-style URLs when the `UsePathStyle` parameter is enabled.