### PR TITLE
feat: make encryption optional

### DIFF
--- a/cmd/talos-backup/main.go
+++ b/cmd/talos-backup/main.go
@@ -33,7 +33,7 @@ func run() error {
 		return fmt.Errorf("failed to create talos client: %w", err)
 	}
 
-	return service.BackupEncryptedSnapshot(ctx, serviceConfig, talosConfig, talosClient)
+	return service.BackupSnapshot(ctx, serviceConfig, talosConfig, talosClient, serviceConfig.DisableEncryption)
 }
 
 func main() {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -376,7 +376,7 @@ func cleanup(pool *dockertest.Pool, resources ...*dockertest.Resource) error {
 func (suite *integrationTestSuite) TestBackupEncryptedSnapshot() {
 	// when
 	suite.Require().Nil(
-		service.BackupEncryptedSnapshot(suite.ctx, &suite.serviceConfig, suite.talosConfig, suite.talosClient),
+		service.BackupSnapshot(suite.ctx, &suite.serviceConfig, suite.talosConfig, suite.talosClient, false),
 	)
 
 	// then

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -18,6 +18,7 @@ type ServiceConfig struct {
 	ClusterName        string `yaml:"clusterName"`
 	AgeX25519PublicKey string `yaml:"ageX25519PublicKey"`
 	UsePathStyle       bool   `yaml:"usePathStyle"`
+	DisableEncryption  bool   `yaml:"disableEncryption"`
 }
 
 const (
@@ -27,6 +28,7 @@ const (
 	s3PrefixEnvVar           = "S3_PREFIX"
 	clusterNameEnvVar        = "CLUSTER_NAME"
 	usePathStyleEnvVar       = "USE_PATH_STYLE"
+	disableEncryptionEnvVar  = "DISABLE_ENCRYPTION"
 	ageX25519PublicKeyEnvVar = "AGE_X25519_PUBLIC_KEY"
 )
 
@@ -39,6 +41,7 @@ func GetServiceConfig() *ServiceConfig {
 		S3Prefix:           os.Getenv(s3PrefixEnvVar),
 		ClusterName:        os.Getenv(clusterNameEnvVar),
 		UsePathStyle:       os.Getenv(usePathStyleEnvVar) == "false",
+		DisableEncryption:  os.Getenv(disableEncryptionEnvVar) == "true",
 		AgeX25519PublicKey: os.Getenv(ageX25519PublicKeyEnvVar),
 	}
 }


### PR DESCRIPTION
This commit modifies the `BackupSnapshot` function in the `service` package to add support for encryption of the etcd snapshot before uploading it to S3. The `BackupSnapshot` function now takes an additional optional boolean parameter `encrypt` which determines whether encryption should be enabled or not, enabled is the default. If encryption is enabled, the etcd snapshot is encrypted using the provided public key before uploading it to S3. If encryption is disabled, the etcd snapshot is uploaded as is. This change allows users to choose whether they want to encrypt their etcd snapshots or not.

Signed-off-by: Cedric Grard
<cedric.grard@eurofiber.com>