### PR TITLE
fix: avoid extra slashes in the s3 path

### DIFF
--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -53,9 +53,19 @@ func PushSnapshot(ctx context.Context, conf buconfig.S3Info, s3c *s3.Client, s3P
 
 	defer closeOnce() //nolint:errcheck
 
+	// Remove the first slash from s3Prefix
+	if len(s3Prefix) > 0 && s3Prefix[0] == '/' {
+		s3Prefix = s3Prefix[1:]
+	}
+
+	// Add a trailing slash to s3Prefix
+	if len(s3Prefix) > 0 && s3Prefix[len(s3Prefix)-1] != '/' {
+		s3Prefix = s3Prefix + "/"
+	}
+
 	s3In := &s3.PutObjectInput{
 		Bucket: aws.String(conf.Bucket),
-		Key:    aws.String(fmt.Sprintf("%s/%s", s3Prefix, snapPath)),
+		Key:    aws.String(fmt.Sprintf("%s%s", s3Prefix, snapPath)),
 		Body:   f,
 	}
 


### PR DESCRIPTION
Hello!

There are some s3 systems, which don’t like multiple slashes in s3 key path. For example, if ```S3_PREFIX``` is ```/ ``` the path will be ```bucket///snapshot.snap```.

I’ve added two operations: removing the first slash from ```S3_PREFIX``` if exists and adding a trailing slash if it doesn’t exists. 

So. it will be:

| S3_PREFIX | before | after |
| --- | --- | --- |
|  ```/``` | ```bucket///snapshot.snap``` | ```bucket/snapshot.snap``` |
| ```test``` | ```bucket/test/snapshot.snap``` |  ```bucket/test/snapshot.snap``` |
| ```/test/``` | ```bucket//test//snapshot.snap``` | ```bucket/test/snapshot.snap``` |