### PR TITLE
feat: add age multiple recipients support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-28T14:35:15Z by kres 784fa1f.
+# Generated on 2025-09-22T14:57:54Z by kres fdbc9fc.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -26,13 +26,12 @@ jobs:
       packages: write
       pull-requests: read
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
     steps:
       - name: gather-system-info
         id: system-info
-        uses: kenchan0130/actions-system-info@v1.3.1
+        uses: kenchan0130/actions-system-info@v1.4.0
         continue-on-error: true
       - name: print-system-info
         run: |
@@ -70,18 +69,9 @@ jobs:
       - name: base
         run: |
           make base
-      - name: unit-tests
-        run: |
-          make unit-tests
-      - name: unit-tests-race
-        run: |
-          make unit-tests-race
       - name: talos-backup
         run: |
           make talos-backup
-      - name: lint
-        run: |
-          make lint
       - name: Login to registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -128,3 +118,100 @@ jobs:
           files: |-
             _out/talos-backup-*
             _out/sha*.txt
+  lint:
+    runs-on:
+      group: generic
+    if: github.event_name == 'pull_request'
+    needs:
+      - default
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@v5
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: lint
+        run: |
+          make lint
+  unit-tests:
+    runs-on:
+      group: generic
+    if: github.event_name == 'pull_request'
+    needs:
+      - default
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@v1.4.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@v5
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: unit-tests
+        run: |
+          make unit-tests
+      - name: unit-tests-race
+        run: |
+          make unit-tests-race

--- a/.github/workflows/slack-notify-ci-failure.yaml
+++ b/.github/workflows/slack-notify-ci-failure.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-28T14:35:15Z by kres 784fa1f.
+# Generated on 2025-09-22T14:57:54Z by kres fdbc9fc.
 
 "on":
   workflow_run:
@@ -14,8 +14,7 @@ name: slack-notify-failure
 jobs:
   slack-notify:
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'pull_request'
     steps:
       - name: Slack Notify

--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-28T14:35:15Z by kres 784fa1f.
+# Generated on 2025-09-22T14:57:54Z by kres fdbc9fc.
 
 "on":
   workflow_run:
@@ -12,8 +12,7 @@ name: slack-notify
 jobs:
   slack-notify:
     runs-on:
-      - self-hosted
-      - generic
+      group: generic
     if: github.event.workflow_run.conclusion != 'skipped'
     steps:
       - name: Get PR number

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-28T14:35:15Z by kres 784fa1f.
+# Generated on 2025-09-22T14:57:54Z by kres fdbc9fc.
 
 "on":
   schedule:
@@ -15,7 +15,7 @@ jobs:
       - ubuntu-latest
     steps:
       - name: Close stale issues and PRs
-        uses: actions/stale@v9.1.0
+        uses: actions/stale@v10.0.0
         with:
           close-issue-message: This issue was closed because it has been stalled for 7 days with no activity.
           days-before-issue-close: "5"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# syntax = docker/dockerfile-upstream:1.17.1-labs
+# syntax = docker/dockerfile-upstream:1.18.0-labs
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-28T14:35:15Z by kres 784fa1f.
+# Generated on 2025-09-22T14:57:54Z by kres fdbc9fc.
 
 ARG TOOLCHAIN
 
@@ -14,7 +14,7 @@ FROM ghcr.io/siderolabs/ca-certificates:v1.11.0 AS image-ca-certificates
 FROM ghcr.io/siderolabs/fhs:v1.11.0 AS image-fhs
 
 # runs markdownlint
-FROM docker.io/oven/bun:1.2.20-alpine AS lint-markdown
+FROM docker.io/oven/bun:1.2.22-alpine AS lint-markdown
 WORKDIR /src
 RUN bun i markdownlint-cli@0.45.0 sentences-per-line@0.3.0
 COPY .markdownlint.json .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-08-28T14:35:15Z by kres 784fa1f.
+# Generated on 2025-09-22T14:57:54Z by kres fdbc9fc.
 
 # common variables
 
@@ -17,16 +17,16 @@ WITH_RACE ?= false
 REGISTRY ?= ghcr.io
 USERNAME ?= siderolabs
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
-PROTOBUF_GO_VERSION ?= 1.36.7
+PROTOBUF_GO_VERSION ?= 1.36.9
 GRPC_GO_VERSION ?= 1.5.1
-GRPC_GATEWAY_VERSION ?= 2.27.1
+GRPC_GATEWAY_VERSION ?= 2.27.2
 VTPROTOBUF_VERSION ?= 0.6.0
-GOIMPORTS_VERSION ?= 0.36.0
+GOIMPORTS_VERSION ?= 0.37.0
 GOMOCK_VERSION ?= 0.6.0
 DEEPCOPY_VERSION ?= v0.5.8
 GOLANGCILINT_VERSION ?= v2.4.0
-GOFUMPT_VERSION ?= v0.8.0
-GO_VERSION ?= 1.25.0
+GOFUMPT_VERSION ?= v0.9.1
+GO_VERSION ?= 1.25.1
 GO_BUILDFLAGS ?=
 GO_LDFLAGS ?=
 CGO_ENABLED ?= 0
@@ -222,6 +222,9 @@ lint-markdown:  ## Runs markdownlint.
 
 .PHONY: lint
 lint: lint-golangci-lint lint-gofumpt lint-govulncheck lint-markdown  ## Run all linters for the project.
+
+.PHONY: lint-fmt
+lint-fmt: lint-golangci-lint-fmt  ## Run all linter formatters and fix up the source tree.
 
 .PHONY: image-talos-backup
 image-talos-backup:  ## Builds image for talos-backup.

--- a/cronjob.sample.yaml
+++ b/cronjob.sample.yaml
@@ -32,8 +32,9 @@ spec:
                 # S3_PREFIX is optional; if omitted it will fall back to the cluster name.
                 - name: S3_PREFIX
                   value: 'important/backups'
+                # AGE_X25519_PUBLIC_KEY supports multiple recipients as comma-separated keys
                 - name: AGE_X25519_PUBLIC_KEY
-                  value: 'age1khpnnl86pzx96ttyjmldptsl5yn2v9jgmmzcjcufvk00ttkph9zs0ytgec'
+                  value: 'age1khpnnl86pzx96ttyjmldptsl5yn2v9jgmmzcjcufvk00ttkph9zs0ytgec,age1majtfe4q0u030xcjg0ent45stsfev28fjwy0saxqw4c3x85gge5s5gtkwx'
                 # ENABLE_COMPRESSION is optional; set this to true if you want to add compression to your etcd snapshot
                 # If enabled, snapshot will be compressed with zstd algorithm
                 - name: ENABLE_COMPRESSION

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -340,7 +340,10 @@ func (suite *integrationTestSuite) startMinIO(ctx context.Context, pool *dockert
 	suite.serviceConfig.CustomS3Endpoint = "http://" + suite.minioResource.Container.NetworkSettings.IPAddress + ":" + minioS3APIPort
 	suite.serviceConfig.Bucket = bucketName
 	suite.serviceConfig.S3Prefix = "testdata/snapshots"
-	suite.serviceConfig.AgeX25519PublicKey = "age1khpnnl86pzx96ttyjmldptsl5yn2v9jgmmzcjcufvk00ttkph9zs0ytgec"
+	suite.serviceConfig.AgeX25519PublicKey = []string{
+		"age1khpnnl86pzx96ttyjmldptsl5yn2v9jgmmzcjcufvk00ttkph9zs0ytgec",
+		"age1majtfe4q0u030xcjg0ent45stsfev28fjwy0saxqw4c3x85gge5s5gtkwx",
+	}
 
 	return nil
 }

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -6,19 +6,20 @@ package config
 
 import (
 	"os"
+	"strings"
 )
 
 // ServiceConfig holds configuration values for the etcd snapshot service.
 // The parameters CustomS3Endpoint, s3Prefix, clusterName are optional.
 type ServiceConfig struct {
-	CustomS3Endpoint   string `yaml:"customS3Endpoint"`
-	Bucket             string `yaml:"bucket"`
-	Region             string `yaml:"region"`
-	S3Prefix           string `yaml:"s3Prefix"`
-	ClusterName        string `yaml:"clusterName"`
-	AgeX25519PublicKey string `yaml:"ageX25519PublicKey"`
-	EnableCompression  bool   `yaml:"enableCompression"`
-	DisableEncryption  bool   `yaml:"disableEncryption"`
+	CustomS3Endpoint   string   `yaml:"customS3Endpoint"`
+	Bucket             string   `yaml:"bucket"`
+	Region             string   `yaml:"region"`
+	S3Prefix           string   `yaml:"s3Prefix"`
+	ClusterName        string   `yaml:"clusterName"`
+	AgeX25519PublicKey []string `yaml:"ageX25519PublicKey"`
+	EnableCompression  bool     `yaml:"enableCompression"`
+	DisableEncryption  bool     `yaml:"disableEncryption"`
 }
 
 const (
@@ -42,6 +43,6 @@ func GetServiceConfig() *ServiceConfig {
 		ClusterName:        os.Getenv(clusterNameEnvVar),
 		EnableCompression:  os.Getenv(enableCompressionEnvVar) == "true",
 		DisableEncryption:  os.Getenv(disableEncryptionEnvVar) == "true",
-		AgeX25519PublicKey: os.Getenv(ageX25519PublicKeyEnvVar),
+		AgeX25519PublicKey: strings.Split(os.Getenv(ageX25519PublicKeyEnvVar), ","),
 	}
 }


### PR DESCRIPTION
**Add support for multiple age encryption recipients**
This PR adds the ability to encrypt backups for multiple recipients by providing comma-separated age public keys in the AGE_X25519_PUBLIC_KEY environment variable. This allows multiple people to decrypt the same backup using their respective private keys.

**Changes:**
- Modified encryptFile function to parse comma-separated public keys

**Usage:** 
Set AGE_X25519_PUBLIC_KEY="age1key1,age1key2,age1key3" to encrypt for multiple recipients.