### PR TITLE
feat: add path style S3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ About compression, it is disabled by default.
 You can turn it on by setting ENABLE_COMPRESSION to "true" in the environement variable list in `cronjob.sample.yaml`.
 Talos backup will compress the etcd snapshot with zstd algorithm before encrypt it.
 
+### Use Path Style
+
+For local or self-hosted S3-compatible providers that require path-style addressing, set `USE_PATH_STYLE` to `"true"`.
+When `USE_PATH_STYLE` is unset or `"false"`, talos-backup keeps the default minio-go bucket lookup behavior.
+
 ### Retention
 
 The easiest way to set retention is to set the lifecycle policy on the storage bucket itself.

--- a/cronjob.sample.yaml
+++ b/cronjob.sample.yaml
@@ -33,6 +33,9 @@ spec:
                 # CUSTOM_S3_ENDPOINT is optional; if omitted the service will fallback to default AWS endpoints.
                 - name: CUSTOM_S3_ENDPOINT
                   value: https://my-s3-compatible-api.example.com:1234
+                # USE_PATH_STYLE is optional; set to true for S3-compatible endpoints that require path-style addressing.
+                - name: USE_PATH_STYLE
+                  value: 'true'
                 - name: BUCKET
                   value: talos-backups
                 # CLUSTER_NAME is optional; if omitted it will fall back to the name of the default context.

--- a/pkg/config/service.go
+++ b/pkg/config/service.go
@@ -11,12 +11,13 @@ import (
 
 // ServiceConfig holds configuration values for the etcd snapshot service.
 // The parameters CustomS3Endpoint, s3Prefix, clusterName are optional.
-type ServiceConfig struct {
+type ServiceConfig struct { //nolint:govet
 	CustomS3Endpoint      string   `yaml:"customS3Endpoint"`
 	Bucket                string   `yaml:"bucket"`
 	Region                string   `yaml:"region"`
 	S3Prefix              string   `yaml:"s3Prefix"`
 	ClusterName           string   `yaml:"clusterName"`
+	UsePathStyle          bool     `yaml:"usePathStyle"`
 	AgeRecipientPublicKey []string `yaml:"ageRecipientPublicKey"`
 	EnableCompression     bool     `yaml:"enableCompression"`
 	DisableEncryption     bool     `yaml:"disableEncryption"`
@@ -28,6 +29,7 @@ const (
 	regionEnvVar                = "AWS_REGION"
 	s3PrefixEnvVar              = "S3_PREFIX"
 	clusterNameEnvVar           = "CLUSTER_NAME"
+	usePathStyleEnvVar          = "USE_PATH_STYLE"
 	enableCompressionEnvVar     = "ENABLE_COMPRESSION"
 	disableEncryptionEnvVar     = "DISABLE_ENCRYPTION"
 	ageRecipientPublicKeyEnvVar = "AGE_RECIPIENT_PUBLIC_KEY"
@@ -46,8 +48,9 @@ func GetServiceConfig() *ServiceConfig {
 		Region:                os.Getenv(regionEnvVar),
 		S3Prefix:              os.Getenv(s3PrefixEnvVar),
 		ClusterName:           os.Getenv(clusterNameEnvVar),
-		EnableCompression:     os.Getenv(enableCompressionEnvVar) == "true",
-		DisableEncryption:     os.Getenv(disableEncryptionEnvVar) == "true",
+		UsePathStyle:          os.Getenv(usePathStyleEnvVar) == "true",      //nolint:goconst
+		EnableCompression:     os.Getenv(enableCompressionEnvVar) == "true", //nolint:goconst
+		DisableEncryption:     os.Getenv(disableEncryptionEnvVar) == "true", //nolint:goconst
 		AgeRecipientPublicKey: ageRecipientPublicKey,
 	}
 }

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -40,11 +40,17 @@ func CreateClientWithCustomEndpoint(ctx context.Context, svcConf *buconfig.Servi
 		},
 	)
 
-	client, err := minio.New(endpoint, &minio.Options{
+	options := &minio.Options{
 		Creds:  creds,
 		Secure: useSSL,
 		Region: svcConf.Region,
-	})
+	}
+
+	if svcConf.UsePathStyle {
+		options.BucketLookup = minio.BucketLookupPath
+	}
+
+	client, err := minio.New(endpoint, options)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load S3 configuration: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Add `USE_PATH_STYLE` service configuration for S3-compatible providers that require path-style bucket addressing.
- Wire the option into the MinIO client via `minio.BucketLookupPath` when enabled.
- Document the setting and enable it in the sample CronJob for local/self-hosted S3-compatible endpoints.

## Verification
- `go test ./...`
- `go build ./...`

Fixes #59